### PR TITLE
Added function to set vertex colors in GLC_Mesh

### DIFF
--- a/src/geometry/glc_mesh.h
+++ b/src/geometry/glc_mesh.h
@@ -232,6 +232,10 @@ public:
 	//! Add Colors
 	inline void addColors(const GLfloatVector& colors)
 	{*(m_MeshData.colorVectorHandle())+= colors;}
+	
+	//! Replace colors
+	inline void setColors(const GLfloatVector& colors)
+	{*(m_MeshData.colorVectorHandle()) = colors;}
 
 	//! Add triangles
 	GLC_uint addTriangles(GLC_Material*, const IndexList&, const int lod= 0, double accuracy= 0.0);


### PR DESCRIPTION
This new function unlike addColors() replaces all of the vertex colors.
