### PR TITLE
Fix bad reading/writing of visible state in 3DXML format (v3 and v4)

### DIFF
--- a/src/lib/io/glc_3dxmltoworld.cpp
+++ b/src/lib/io/glc_3dxmltoworld.cpp
@@ -1577,8 +1577,8 @@ void GLC_3dxmlToWorld::loadDefaultView()
 
 void GLC_3dxmlToWorld::loadV3DefaultViewProperty()
 {
-	goToElement(m_pStreamReader, "OccurrenceId");
-	unsigned int occurrenceId= getContent(m_pStreamReader, "OccurrenceId").toUInt();
+	goToElement(m_pStreamReader, "OccurenceId");
+	unsigned int occurrenceId= getContent(m_pStreamReader, "OccurenceId").toUInt();
 
 	// Load the graphics properties
 	while(endElementNotReached(m_pStreamReader, "DefaultViewProperty"))
@@ -1660,7 +1660,7 @@ void GLC_3dxmlToWorld::loadV4DefaultViewProperty()
 
 	while(endElementNotReached(m_pStreamReader, "DefaultViewProperty"))
 	{
-		if ((QXmlStreamReader::StartElement == m_pStreamReader->tokenType()) && (m_pStreamReader->name() == "OccurrenceId"))
+		if ((QXmlStreamReader::StartElement == m_pStreamReader->tokenType()) && (m_pStreamReader->name() == "OccurenceId"))
 		{
 			pV4OccurrenceAttrib->m_Path= loadOccurrencePath();
 		}
@@ -1699,7 +1699,7 @@ void GLC_3dxmlToWorld::loadV4DefaultViewProperty()
 QList<unsigned int> GLC_3dxmlToWorld::loadOccurrencePath()
 {
 	QList<unsigned int> path;
-	while(endElementNotReached(m_pStreamReader, "OccurrenceId"))
+	while(endElementNotReached(m_pStreamReader, "OccurenceId"))
 	{
 		if ((QXmlStreamReader::StartElement == m_pStreamReader->tokenType()) && (m_pStreamReader->name() == "id"))
 		{

--- a/src/lib/io/glc_worldto3dxml.cpp
+++ b/src/lib/io/glc_worldto3dxml.cpp
@@ -1176,14 +1176,14 @@ void GLC_WorldTo3dxml::writeOccurrenceDefaultViewProperty(const GLC_StructOccurr
 	Q_ASSERT(NULL != pInstance);
 	const bool isVisible= pOccurrence->isVisible();
 	m_pOutStream->writeStartElement("DefaultViewProperty");
-	m_pOutStream->writeStartElement("OccurrenceId");
+	m_pOutStream->writeStartElement("OccurenceId");
 	const QString prefix= "urn:3DXML:" + QFileInfo(m_FileName).fileName() + "#";
 	const int pathSize= path.size();
 	for (int i= 0; i < pathSize; ++i)
 	{
 		m_pOutStream->writeTextElement("id", prefix + QString::number(path.at(i)));
 	}
-	m_pOutStream->writeEndElement(); // OccurrenceId
+	m_pOutStream->writeEndElement(); // OccurenceId
 
 	if (pOccurrence->isFlexible())
 	{


### PR DESCRIPTION
Hello,

I noticed that Parts hidden in Catia were not hidden in GLC_Player / GLC_lib. There is a typo when reading the 3DXML file. I fixed it and now it works.

Regards,
Loïc