### PR TITLE
Mac OS X: embed the libraries in the bundle

### DIFF
--- a/glc_lib.pri
+++ b/glc_lib.pri
@@ -1,15 +1,23 @@
+LDIR = $$_PRO_FILE_PWD_/../../lib
+INCLUDEPATH += "$$LDIR"
+
 win32 {
-    LIBS += -L"../../lib" -lGLC_lib3
-    INCLUDEPATH += "../../lib"
+    LIBS += -L"$$LDIR" -lGLC_lib3
     LIBS += -lopengl32
 }
 
 macx {
-     LIBS += -L"../../lib" -lGLC_lib.3
-     INCLUDEPATH += "../../lib/"
+     LIBS += -L"$$LDIR" -lGLC_lib.3
+
+     # bundle the .dylib files
+     glclib.path = Contents/Frameworks
+     glclib.files = $$files($$LDIR/*.dylib)
+     QMAKE_BUNDLE_DATA += glclib
+
+     # point @rpath to the libraries
+     QMAKE_RPATHDIR += @executable_path/../Frameworks
 }
 
 unix:!macx {
-     LIBS += -L"../../lib" -l:libGLC_lib.so.3
-     INCLUDEPATH += "../../lib/"
+     LIBS += -L"$$LDIR" -l:libGLC_lib.so.3
 }

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -33,6 +33,10 @@ INCLUDEPATH += ./3rdparty/quazip
 
 RESOURCES += glc_lib.qrc
 
+macx {
+    # make the system find the library in the @rpath
+    QMAKE_LFLAGS_SONAME = -Wl,-install_name,@rpath/
+}
 # Input					
 
 HEADERS_QUAZIP += \


### PR DESCRIPTION
I made a change so that the .dylib files can be embedded and found in the app bundle.
Basically the library is renamed `@rpath/libGLC_lib.3.dylib`, then the executable file is told that @rpath is a relative path.

after change:
```
$ otool -L example01.app/Contents/MacOS/example01 
example01.app/Contents/MacOS/example01:
	@rpath/libGLC_lib.3.dylib (compatibility version 3.0.0, current version 3.0.0)
	/usr/local/opt/qt@5/lib/QtOpenGL.framework/Versions/5/QtOpenGL (compatibility version 5.15.0, current version 5.15.7)
	/usr/local/opt/qt@5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.15.0, current version 5.15.7)
	/usr/local/opt/qt@5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.15.0, current version 5.15.7)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2299.30.112)
	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 306.3.4)
	/usr/local/opt/qt@5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.15.0, current version 5.15.7)
	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.36.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
```
```
$ otool -l example01.app/Contents/MacOS/example01  
(..snip...)
Load command 25
          cmd LC_RPATH
      cmdsize 48
         path @executable_path/../Frameworks (offset 12)
(..snip...)
```
some background information is available here: 
https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html
